### PR TITLE
Update to Cats 1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,11 +25,11 @@ lazy val core = project
   .settings(scalaVersion := "2.12.3")
   .settings(libraryDependencies ++= commonDeps ++ freestyleCoreDeps() ++
     Seq(
-      %%("frees-core", "0.5.1"),
-      %%("frees-http4s", "0.5.1"),
-      %%("frees-config", "0.5.1"),
-      %%("frees-logging", "0.5.1"),
-      %%("frees-rpc", "0.6.1"),
+      %%("frees-core"),
+      %%("frees-http4s"),
+      %%("frees-config"),
+      %%("frees-logging"),
+      %%("frees-rpc"),
       %%("cats-effect"),
       %%("http4s-dsl"),
       %%("http4s-blaze-client"),
@@ -47,8 +47,8 @@ lazy val metrics = project
   .settings(scalaMetaSettings: _*)
   .settings(libraryDependencies ++= commonDeps ++ freestyleCoreDeps() ++
     Seq(
-      %%("frees-core", "0.5.1"),
-      %%("frees-rpc", "0.6.1"),
+      %%("frees-core"),
+      %%("frees-rpc"),
       %("joda-time")
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -25,16 +25,15 @@ lazy val core = project
   .settings(scalaVersion := "2.12.3")
   .settings(libraryDependencies ++= commonDeps ++ freestyleCoreDeps() ++
     Seq(
-      %%("frees-core"),
-      %%("frees-http4s"),
-      %%("frees-config"),
-      %%("frees-logging"),
-      %%("frees-rpc"),
+      %%("frees-core", "0.5.1"),
+      %%("frees-http4s", "0.5.1"),
+      %%("frees-config", "0.5.1"),
+      %%("frees-logging", "0.5.1"),
+      %%("frees-rpc", "0.6.1"),
       %%("cats-effect"),
       %%("http4s-dsl"),
       %%("http4s-blaze-client"),
       %%("http4s-blaze-server"),
-      %%("pbdirect"),
       %("joda-time")
     )
   )
@@ -48,8 +47,8 @@ lazy val metrics = project
   .settings(scalaMetaSettings: _*)
   .settings(libraryDependencies ++= commonDeps ++ freestyleCoreDeps() ++
     Seq(
-      %%("frees-core"),
-      %%("frees-rpc"),
+      %%("frees-core", "0.5.1"),
+      %%("frees-rpc", "0.6.1"),
       %("joda-time")
     )
   )

--- a/core/src/main/scala/model/models.scala
+++ b/core/src/main/scala/model/models.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package freestyle
 package opscenter
 
-import freestyle._
+import freestyle.free._
 import freestyle.rpc.protocol._
 
 object models {

--- a/core/src/main/scala/opscenter.scala
+++ b/core/src/main/scala/opscenter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 package freestyle
 package opscenter
 
-import freestyle._
-import freestyle.config.ConfigM
-import freestyle.logging._
+import freestyle.free._
+import freestyle.free.config.ConfigM
+import freestyle.free.logging._
 import org.http4s.implicits._
 import org.http4s.HttpService
 import org.http4s.server.blaze.BlazeBuilder

--- a/core/src/main/scala/runtime/endpoints.scala
+++ b/core/src/main/scala/runtime/endpoints.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package opscenter
 package runtime
 package endpoints
 
-import freestyle._
-import freestyle.implicits._
+import freestyle.free._
+import freestyle.free.implicits._
 import freestyle.metrics.models.{Metric, MetricsList}
 import freestyle.metrics.models.Metric.implicits._
 import freestyle.opscenter.services.microservices._
@@ -32,12 +32,15 @@ import pbdirect._
 import _root_.fs2.{Scheduler, Stream}
 import _root_.fs2._
 import java.io.File
+
 import org.http4s.websocket.WebsocketBits.{Binary, Text}
 import org.http4s.websocket.WebsocketBits.WebSocketFrame
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import cats.effect.IO
 import scala.concurrent.duration._
 import org.joda.time.DateTime
+
 import scala.util.Random
 
 object implicits {

--- a/core/src/main/scala/runtime/server.scala
+++ b/core/src/main/scala/runtime/server.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/services/microservices.scala
+++ b/core/src/main/scala/services/microservices.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics/src/main/scala/metrics.scala
+++ b/metrics/src/main/scala/metrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 package freestyle
 package metrics
 
-import freestyle._
-import freestyle.config.ConfigM
+import freestyle.free._
+import freestyle.free.config.ConfigM
 import cats.effect.IO
 import cats.implicits._
 

--- a/metrics/src/main/scala/model/models.scala
+++ b/metrics/src/main/scala/model/models.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics/src/main/scala/runtime/default.scala
+++ b/metrics/src/main/scala/runtime/default.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package metrics
 package runtime
 package default
 
-import freestyle._
-import freestyle.implicits._
+import freestyle.free._
+import freestyle.free.implicits._
 import freestyle.metrics.models.{Metric, MetricsList}
 import freestyle.metrics.models.Metric.implicits._
 import cats.effect.IO

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.2
+sbt.version = 1.0.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 resolvers += Resolver.sonatypeRepo("releases")
 
-addSbtPlugin("io.frees" % "sbt-freestyle" % "0.3.14")
+addSbtPlugin("io.frees" % "sbt-freestyle" % "0.3.15")
 addSbtPlugin("io.frees" % "sbt-frees-protogen" % "0.0.14")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 resolvers += Resolver.sonatypeRepo("releases")
 
 addSbtPlugin("io.frees" % "sbt-freestyle" % "0.3.14")
-addSbtPlugin("io.frees" % "sbt-frees-protogen" % "0.0.13")
+addSbtPlugin("io.frees" % "sbt-frees-protogen" % "0.0.14")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 resolvers += Resolver.sonatypeRepo("releases")
 
-addSbtPlugin("io.frees" % "sbt-freestyle" % "0.3.7")
+addSbtPlugin("io.frees" % "sbt-freestyle" % "0.3.14")
 addSbtPlugin("io.frees" % "sbt-frees-protogen" % "0.0.13")

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,17 +20,20 @@ import cats.Id
 import freestyle.opscenter.runtime.server.implicits._
 import freestyle.opscenter.runtime.endpoints.implicits._
 import freestyle.metrics.runtime.default.implicits._
-import freestyle.loggingJVM.implicits._
-import freestyle._
+import freestyle.free.loggingJVM.implicits._
+import freestyle.free._
 import freestyle.opscenter._
-import freestyle.implicits._
-import freestyle.config.implicits._
+import freestyle.free.implicits._
+import freestyle.free.config.implicits._
 import cats.implicits._
 import _root_.fs2.Stream
-import cats.effect.{IO}
+import cats.effect.IO
+import freestyle.free.config.ConfigM
+import freestyle.free.logging.LoggingM
+import freestyle.metrics.Metrics
 import org.http4s.server.blaze._
-import org.http4s.util.StreamApp
-import org.http4s.util.StreamApp.ExitCode
+import org.http4s.util._
+import fs2.StreamApp.ExitCode
 
 import scala.util.Try
 
@@ -59,7 +62,21 @@ object Main extends StreamApp[IO] {
 
   }
 
-  override def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] =
+  override def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] = {
+    /*
+    val http: Http
+    val services: Services
+    val metrics: Metrics
+     */
+
+    implicitly[FSHandler[ConfigM.Op, Try]]
+    implicitly[FSHandler[LoggingM.Op, Try]]
+    implicitly[FSHandler[Services.Op, Try]]
+    implicitly[FSHandler[Metrics.Op, Try]]
+    implicitly[FSHandler[Http.Op, Try]]
+
     bootstrap[OpscenterApp.Op].interpret[Try].fold(e => Stream.fail(e), _.serve)
+
+  }
 
 }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -62,21 +62,7 @@ object Main extends StreamApp[IO] {
 
   }
 
-  override def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] = {
-    /*
-    val http: Http
-    val services: Services
-    val metrics: Metrics
-     */
-
-    implicitly[FSHandler[ConfigM.Op, Try]]
-    implicitly[FSHandler[LoggingM.Op, Try]]
-    implicitly[FSHandler[Services.Op, Try]]
-    implicitly[FSHandler[Metrics.Op, Try]]
-    implicitly[FSHandler[Http.Op, Try]]
-
-    bootstrap[OpscenterApp.Op].interpret[Try].fold(e => Stream.fail(e), _.serve)
-
-  }
+  override def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] =
+    bootstrap[OpscenterApp.Op].interpret[Try].fold(e => Stream.raiseError(e), _.serve)
 
 }


### PR DESCRIPTION
It resolves #37.

I removed `pbdirect` as dependency because `frees-rpc` is using this dependency and for this reason, we have it transitively
  